### PR TITLE
add brew formula

### DIFF
--- a/je.rb
+++ b/je.rb
@@ -1,0 +1,16 @@
+class Je < Formula
+  desc "Fast JSON to TSV/CSV/JSON Extractor"
+  homepage "https://github.com/tamediadigital/je"
+  url "https://github.com/tamediadigital/je/archive/v0.0.0.tar.gz"
+  sha256 "1400063bc4f70bd532d42a664f25244a6517c6fd135ec2c0a73c96437795db9d"
+  head "https://github.com/tamediadigital/je.git"
+
+  depends_on "dub" => :build
+  depends_on "ldc" => [:build, "developer"]
+
+  def install
+    compiler = "ldmd2"
+    system "dub", "build", "--compiler=" + compiler, "--build=release-native"
+    bin.install "je"
+  end
+end


### PR DESCRIPTION
This is the first Homebrew formula for DUB package.
Current issues:
1. DMD+DUB pair can not be used as compiler dependency because if DMD installed with brew, then DUB executes the shell, which does not sees the DMD. This mean that we have a bug in DUB.
2. LDC's stable is too old for JE, we need at least a `--devel` for now. But Homebrew does not allow to specify --devel/--HEAD options for dependencies.

Current workaround:
```
brew rm ldc
brew install ldc --devel
brew link --overwrite ldc
brew install je.rb --HEAD
```

After the next major stable LDC release I will push this formula to the Homebrew core.